### PR TITLE
feat: Implement initial FastAPI API layer

### DIFF
--- a/api/deps/__init__.py
+++ b/api/deps/__init__.py
@@ -1,0 +1,6 @@
+# This file makes 'deps' a Python package.
+# It can also be used to make specific dependencies available at the package level.
+
+from .db import get_db
+
+__all__ = ["get_db"]

--- a/api/deps/auth.py
+++ b/api/deps/auth.py
@@ -1,0 +1,98 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+
+# from passlib.context import CryptContext  # F401: Unused
+from sqlalchemy.orm import Session
+
+from ai_trader.config import settings
+from ai_trader import models
+from schemas import token as token_schema
+
+# from schemas import user as user_schema  # F401: Unused
+from crud import crud_user
+from .db import get_db  # Import get_db from within deps
+
+
+# --- Configuration ---
+SECRET_KEY = settings.SECRET_KEY
+ALGORITHM = "HS256"  # Standard algorithm for JWT
+ACCESS_TOKEN_EXPIRE_MINUTES = 30  # Token validity period
+
+oauth2_scheme = OAuth2PasswordBearer(
+    tokenUrl="api/v1/users/login"
+)  # Corrected: Relative to server root
+
+
+# Password utilities (verify_password, get_password_hash) are now expected to be imported
+# from crud.crud_user or a dedicated security utility module if needed by auth functions directly.
+# For token creation and validation, they are not directly used here.
+# The login endpoint itself uses crud_user.authenticate which handles password verification.
+
+
+# --- Token Creation ---
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(
+            minutes=ACCESS_TOKEN_EXPIRE_MINUTES
+        )
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+# --- Current User Dependency ---
+async def get_current_user(
+    db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)
+) -> models.User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: Optional[str] = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        token_data = token_schema.TokenData(username=username)
+    except JWTError:
+        raise credentials_exception
+
+    user = crud_user.user.get_user_by_username(db, username=token_data.username)
+    if user is None:
+        raise credentials_exception
+    if user.is_deleted:  # Check if user is soft-deleted
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Inactive user",
+        )
+    return user
+
+
+async def get_current_active_user(
+    current_user: models.User = Depends(get_current_user),
+) -> models.User:
+    # This function can be expanded to check for other "active" flags if needed
+    # For now, get_current_user already checks is_deleted.
+    # If there were a separate `is_active` field, you'd check it here.
+    # if not current_user.is_active:  # Example if an is_active field existed
+    #     raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user
+
+
+# Optional: Dependency for superuser/admin
+# async def get_current_active_superuser(
+#     current_user: models.User = Depends(get_current_active_user),
+# ) -> models.User:
+#     if not current_user.is_superuser:  # Assuming User model has is_superuser
+#         raise HTTPException(
+#             status_code=403, detail="The user doesn't have enough privileges"
+#         )
+#     return current_user

--- a/api/deps/db.py
+++ b/api/deps/db.py
@@ -1,0 +1,13 @@
+from ai_trader.db.session import SessionLocal
+
+
+def get_db():  # E302 fixed
+    """
+    Dependency injector for FastAPI to get a database session.
+    Ensures the session is closed after the request.
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,57 @@
+from fastapi import FastAPI
+
+from api.routers import users, trades, strategies, analytics
+
+app = FastAPI(
+    title="AI Trader API",
+    description="API for managing trading strategies, trades, users, and analytics.",
+    version="0.1.0",
+    # You can add more metadata here, like terms_of_service, contact, license_info
+    # openapi_tags can be used to add descriptions to your tags
+    openapi_tags=[
+        {
+            "name": "users",
+            "description": "Operations with users. The **login** logic is also here.",
+        },
+        {
+            "name": "trades",
+            "description": "Manage trades.",
+        },
+        {
+            "name": "strategies",
+            "description": "Manage trading strategies.",
+        },
+        {
+            "name": "analytics",
+            "description": "Manage trade analytics data.",
+        },
+    ],
+)
+
+# Include routers
+# It's common to prefix API routes with /api/v1 or similar
+app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
+app.include_router(trades.router, prefix="/api/v1/trades", tags=["trades"])
+app.include_router(strategies.router, prefix="/api/v1/strategies", tags=["strategies"])
+app.include_router(analytics.router, prefix="/api/v1/analytics", tags=["analytics"])
+
+
+@app.get("/", tags=["root"])  # E302 fixed
+async def root():
+    return {"message": "Welcome to AI Trader API. Visit /docs for API documentation."}
+
+
+# Optional: Add custom exception handlers, middleware, etc.
+# For example, to handle SQLAlchemy errors globally:
+# from sqlalchemy.exc import SQLAlchemyError
+# from fastapi import Request, status
+# from fastapi.responses import JSONResponse
+
+# @app.exception_handler(SQLAlchemyError)
+# async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError):
+#     # Log the error for debugging
+#     print(f"SQLAlchemyError: {exc}") # Replace with proper logging
+#     return JSONResponse(
+#         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+#         content={"detail": "An internal database error occurred."},
+#     )

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -1,0 +1,10 @@
+# This file makes 'routers' a Python package.
+# It can be used to gather all routers for easier import in main.py
+
+# from . import users
+# from . import trades
+# from . import strategies
+# from . import analytics
+
+# Alternatively, you can define an __all__ list if you prefer
+# __all__ = ["users", "trades", "strategies", "analytics"]

--- a/api/routers/analytics.py
+++ b/api/routers/analytics.py
@@ -1,0 +1,226 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.orm import Session
+from typing import List, Any, Optional
+
+from api.deps import db as deps_db
+from api.deps import auth as deps_auth
+from crud import (
+    crud_analytics,
+)  # Ensure this is the correct import from your crud structure
+from schemas import analytics as analytics_schema  # Ensure this is the correct import
+from ai_trader import models
+
+router = APIRouter()
+
+
+@router.post(
+    "/",
+    response_model=analytics_schema.AnalyticsData,
+    status_code=status.HTTP_201_CREATED,
+    tags=["analytics"],
+)
+def create_analytics_entry(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    analytics_in: analytics_schema.AnalyticsDataCreate,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+    strategy_id: Optional[int] = Query(
+        None, description="Optional ID of the strategy this analytics entry relates to."
+    ),
+) -> Any:
+    """
+    Create a new trade analytics entry for the current user.
+    Can optionally be linked to a strategy.
+    """
+    # Validate strategy_id if provided: check if it exists and belongs to the user
+    if strategy_id:
+        # This import should be from crud.crud_strategy, adjust if your structure is different
+        from crud import crud_strategy  # Local import or move to top if used more
+
+        strategy = crud_strategy.strategy.get_strategy(db=db, strategy_id=strategy_id)
+        if not strategy:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Strategy with id {strategy_id} not found.",
+            )
+        if strategy.user_id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Strategy does not belong to the current user.",
+            )
+
+    created_entry = crud_analytics.trade_analytics.create_analytic_entry(
+        db=db,
+        analytics_in=analytics_in,
+        user_id=current_user.id,
+        strategy_id=strategy_id,
+    )
+    return created_entry
+
+
+@router.get(
+    "/{analytic_id}", response_model=analytics_schema.AnalyticsData, tags=["analytics"]
+)
+def read_analytic_entry(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    analytic_id: int,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Get a specific analytics entry by ID.
+    Only accessible by the user who owns the entry.
+    """
+    entry = crud_analytics.trade_analytics.get_analytic(db=db, analytic_id=analytic_id)
+    if not entry:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Analytics entry not found"
+        )
+    if entry.user_id != current_user.id:
+        # if not current_user.is_superuser: # Admin check
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+    return entry
+
+
+@router.get(
+    "/user/", response_model=List[analytics_schema.AnalyticsData], tags=["analytics"]
+)
+def read_analytics_by_user(
+    db: Session = Depends(deps_db.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Retrieve all analytics entries for the current user.
+    """
+    entries = crud_analytics.trade_analytics.get_analytics_by_user(
+        db=db, user_id=current_user.id, skip=skip, limit=limit
+    )
+    return entries
+
+
+@router.get(
+    "/strategy/{strategy_id}",
+    response_model=List[analytics_schema.AnalyticsData],
+    tags=["analytics"],
+)
+def read_analytics_by_strategy(
+    *,
+    strategy_id: int,
+    db: Session = Depends(deps_db.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Retrieve analytics entries for a specific strategy.
+    Ensures the strategy belongs to the current user.
+    """
+    # Validate strategy: check if it exists and belongs to the user
+    from crud import crud_strategy  # Local import
+
+    strategy = crud_strategy.strategy.get_strategy(db=db, strategy_id=strategy_id)
+    if not strategy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Strategy with id {strategy_id} not found.",
+        )
+    if strategy.user_id != current_user.id:
+        # if not current_user.is_superuser: # Admin check
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Strategy does not belong to the current user or you lack permissions.",
+        )
+
+    entries = crud_analytics.trade_analytics.get_analytics_by_strategy(
+        db=db, strategy_id=strategy_id, skip=skip, limit=limit
+    )
+    return entries
+
+
+@router.put(
+    "/{analytic_id}", response_model=analytics_schema.AnalyticsData, tags=["analytics"]
+)
+def update_analytics_entry(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    analytic_id: int,
+    analytics_in: analytics_schema.AnalyticsDataUpdate,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Update an analytics entry.
+    Only accessible by the user who owns the entry.
+    """
+    db_entry = crud_analytics.trade_analytics.get_analytic(
+        db=db, analytic_id=analytic_id
+    )
+    if not db_entry:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Analytics entry not found"
+        )
+    if db_entry.user_id != current_user.id:
+        # if not current_user.is_superuser: # Admin check
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+
+    updated_entry = crud_analytics.trade_analytics.update_analytic_entry(
+        db=db, db_analytic_entry=db_entry, analytics_in=analytics_in
+    )
+    return updated_entry
+
+
+@router.delete(
+    "/{analytic_id}", response_model=analytics_schema.AnalyticsData, tags=["analytics"]
+)
+def delete_analytics_entry(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    analytic_id: int,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Delete an analytics entry (soft delete).
+    Only accessible by the user who owns the entry.
+    """
+    db_entry = crud_analytics.trade_analytics.get_analytic(
+        db=db, analytic_id=analytic_id
+    )
+    if not db_entry:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Analytics entry not found"
+        )
+    if db_entry.user_id != current_user.id:
+        # if not current_user.is_superuser: # Admin check
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+
+    deleted_entry = crud_analytics.trade_analytics.delete_analytic_entry(
+        db=db, analytic_id=analytic_id
+    )
+    if not deleted_entry:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Analytics entry not found during delete operation",
+        )
+    return deleted_entry
+
+
+# Admin endpoint to get all analytics (example, if needed)
+# @router.get("/all/", response_model=List[analytics_schema.AnalyticsData], tags=["analytics", "admin"])
+# def read_all_analytics_admin(
+#     db: Session = Depends(deps_db.get_db),
+#     skip: int = 0,
+#     limit: int = 100,
+#     current_user: models.User = Depends(deps_auth.get_current_active_superuser), # Requires superuser
+# ) -> Any:
+#     """
+#     Retrieve all analytics entries in the system (Admin only).
+#     """
+#     entries = crud_analytics.trade_analytics.get_all_analytics(db=db, skip=skip, limit=limit)
+#     return entries

--- a/api/routers/strategies.py
+++ b/api/routers/strategies.py
@@ -1,0 +1,156 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List, Any
+
+from api.deps import db as deps_db
+from api.deps import auth as deps_auth
+from crud import crud_strategy
+from schemas import strategy as strategy_schema
+from ai_trader import models
+
+router = APIRouter()
+
+
+@router.post(
+    "/",
+    response_model=strategy_schema.Strategy,
+    status_code=status.HTTP_201_CREATED,
+    tags=["strategies"],
+)
+def create_strategy(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    strategy_in: strategy_schema.StrategyCreate,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Create a new strategy for the current user.
+    """
+    # user_id is taken from current_user.
+    created_strategy = crud_strategy.strategy.create_strategy(
+        db=db, strategy_in=strategy_in, user_id=current_user.id
+    )
+    return created_strategy
+
+
+@router.get(
+    "/{strategy_id}", response_model=strategy_schema.Strategy, tags=["strategies"]
+)
+def read_strategy(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    strategy_id: int,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Get a specific strategy by ID.
+    Only accessible by the user who owns the strategy.
+    """
+    strategy = crud_strategy.strategy.get_strategy(db=db, strategy_id=strategy_id)
+    if not strategy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Strategy not found"
+        )
+    if strategy.user_id != current_user.id:
+        # if not current_user.is_superuser: # Admin check
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+    return strategy
+
+
+@router.get("/", response_model=List[strategy_schema.Strategy], tags=["strategies"])
+def read_strategies_by_user(
+    db: Session = Depends(deps_db.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Retrieve all strategies for the current user.
+    """
+    strategies = crud_strategy.strategy.get_strategies_by_user(
+        db=db, user_id=current_user.id, skip=skip, limit=limit
+    )
+    return strategies
+
+
+@router.put(
+    "/{strategy_id}", response_model=strategy_schema.Strategy, tags=["strategies"]
+)
+def update_strategy(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    strategy_id: int,
+    strategy_in: strategy_schema.StrategyUpdate,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Update a strategy.
+    Only accessible by the user who owns the strategy.
+    """
+    db_strategy = crud_strategy.strategy.get_strategy(db=db, strategy_id=strategy_id)
+    if not db_strategy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Strategy not found"
+        )
+    if db_strategy.user_id != current_user.id:
+        # if not current_user.is_superuser: # Admin check
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+
+    updated_strategy = crud_strategy.strategy.update_strategy(
+        db=db, db_strategy=db_strategy, strategy_in=strategy_in
+    )
+    return updated_strategy
+
+
+@router.delete(
+    "/{strategy_id}", response_model=strategy_schema.Strategy, tags=["strategies"]
+)
+def delete_strategy(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    strategy_id: int,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Delete a strategy (soft delete).
+    Only accessible by the user who owns the strategy.
+    """
+    db_strategy = crud_strategy.strategy.get_strategy(db=db, strategy_id=strategy_id)
+    if not db_strategy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Strategy not found"
+        )
+    if db_strategy.user_id != current_user.id:
+        # if not current_user.is_superuser: # Admin check
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+
+    deleted_strategy = crud_strategy.strategy.delete_strategy(
+        db=db, strategy_id=strategy_id
+    )
+    if not deleted_strategy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Strategy not found during delete operation",
+        )
+    return deleted_strategy
+
+
+# Admin endpoint to get all strategies (example, if needed)
+# @router.get("/all/", response_model=List[strategy_schema.Strategy], tags=["strategies", "admin"])
+# def read_all_strategies_admin(
+#     db: Session = Depends(deps_db.get_db),
+#     skip: int = 0,
+#     limit: int = 100,
+#     current_user: models.User = Depends(deps_auth.get_current_active_superuser), # Requires superuser
+# ) -> Any:
+#     """
+#     Retrieve all strategies in the system (Admin only).
+#     """
+#     strategies = crud_strategy.strategy.get_all_strategies(db=db, skip=skip, limit=limit)
+#     return strategies

--- a/api/routers/trades.py
+++ b/api/routers/trades.py
@@ -1,0 +1,151 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List, Any
+
+from api.deps import db as deps_db
+from api.deps import auth as deps_auth
+from crud import crud_trade
+from schemas import trade as trade_schema
+from ai_trader import models
+
+router = APIRouter()
+
+
+@router.post(
+    "/",
+    response_model=trade_schema.Trade,
+    status_code=status.HTTP_201_CREATED,
+    tags=["trades"],
+)
+def create_trade(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    trade_in: trade_schema.TradeCreate,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Create a new trade for the current user.
+    """
+    # user_id is taken from current_user, not from payload for security.
+    created_trade = crud_trade.trade.create_trade(
+        db=db, trade_in=trade_in, user_id=current_user.id
+    )
+    return created_trade
+
+
+@router.get("/{trade_id}", response_model=trade_schema.Trade, tags=["trades"])
+def read_trade(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    trade_id: int,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Get a specific trade by ID.
+    Only accessible by the user who owns the trade (or admin - not implemented yet).
+    """
+    trade = crud_trade.trade.get_trade(db=db, trade_id=trade_id)
+    if not trade:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Trade not found"
+        )
+    if trade.user_id != current_user.id:
+        # Add admin check here if admins should be able to access any trade
+        # if not current_user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+    return trade
+
+
+@router.get("/", response_model=List[trade_schema.Trade], tags=["trades"])
+def read_trades_by_user(
+    db: Session = Depends(deps_db.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Retrieve all trades for the current user.
+    """
+    trades = crud_trade.trade.get_trades_by_user(
+        db=db, user_id=current_user.id, skip=skip, limit=limit
+    )
+    return trades
+
+
+@router.put("/{trade_id}", response_model=trade_schema.Trade, tags=["trades"])
+def update_trade(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    trade_id: int,
+    trade_in: trade_schema.TradeUpdate,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Update a trade.
+    Only accessible by the user who owns the trade.
+    """
+    db_trade = crud_trade.trade.get_trade(db=db, trade_id=trade_id)
+    if not db_trade:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Trade not found"
+        )
+    if db_trade.user_id != current_user.id:
+        # if not current_user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+
+    updated_trade = crud_trade.trade.update_trade(
+        db=db, db_trade=db_trade, trade_in=trade_in
+    )
+    return updated_trade
+
+
+@router.delete("/{trade_id}", response_model=trade_schema.Trade, tags=["trades"])
+def delete_trade(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    trade_id: int,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Delete a trade (soft delete).
+    Only accessible by the user who owns the trade.
+    """
+    db_trade = crud_trade.trade.get_trade(db=db, trade_id=trade_id)
+    if not db_trade:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Trade not found"
+        )
+    if db_trade.user_id != current_user.id:
+        # if not current_user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
+
+    deleted_trade = crud_trade.trade.delete_trade(db=db, trade_id=trade_id)
+    if (
+        not deleted_trade
+    ):  # Should not happen if previous checks passed, but good for safety
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Trade not found during delete operation",
+        )
+    return deleted_trade
+
+
+# Admin endpoint to get all trades (example, if needed)
+# @router.get("/all/", response_model=List[trade_schema.Trade], tags=["trades", "admin"])
+# def read_all_trades_admin(
+#     db: Session = Depends(deps_db.get_db),
+#     skip: int = 0,
+#     limit: int = 100,
+#     current_user: models.User = Depends(deps_auth.get_current_active_superuser), # Requires superuser
+# ) -> Any:
+#     """
+#     Retrieve all trades in the system (Admin only).
+#     """
+#     trades = crud_trade.trade.get_all_trades(db=db, skip=skip, limit=limit)
+#     return trades

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -1,0 +1,162 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+from typing import Any  # List removed
+
+from api.deps import db as deps_db  # Renamed to avoid conflict
+from api.deps import auth as deps_auth
+from crud import crud_user
+from schemas import user as user_schema
+from schemas import token as token_schema
+from ai_trader import models
+
+router = APIRouter()
+
+
+@router.post(
+    "/register",
+    response_model=user_schema.User,
+    status_code=status.HTTP_201_CREATED,
+    tags=["users"],
+)
+def create_user_registration(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    user_in: user_schema.UserCreate,
+) -> Any:
+    """
+    Create new user.
+    """
+    user = crud_user.user.get_user_by_email(db, email=user_in.email)
+    if user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The user with this email already exists in the system.",
+        )
+    user = crud_user.user.get_user_by_username(db, username=user_in.username)
+    if user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The user with this username already exists in the system.",
+        )
+
+    created_user = crud_user.user.create_user(db=db, user_in=user_in)
+    return created_user
+
+
+@router.post("/login", response_model=token_schema.Token, tags=["users"])
+def login_for_access_token(
+    db: Session = Depends(deps_db.get_db),
+    form_data: OAuth2PasswordRequestForm = Depends(),
+) -> Any:
+    """
+    OAuth2 compatible token login, get an access token for future requests.
+    """
+    user = crud_user.user.authenticate(
+        db, username=form_data.username, password=form_data.password
+    )
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    if user.is_deleted:  # Or check an is_active flag
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Inactive user",
+        )
+    access_token = deps_auth.create_access_token(
+        data={
+            "sub": user.username
+        }  # Typically, 'sub' (subject) is the username or user ID
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.get("/me", response_model=user_schema.User, tags=["users"])
+def read_users_me(
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Get current user.
+    """
+    return current_user
+
+
+@router.put("/me", response_model=user_schema.User, tags=["users"])
+def update_user_me(
+    *,
+    db: Session = Depends(deps_db.get_db),
+    user_in: user_schema.UserUpdate,
+    current_user: models.User = Depends(deps_auth.get_current_active_user),
+) -> Any:
+    """
+    Update own user.
+    """
+    # Check for email conflict if email is being updated
+    if user_in.email and user_in.email != current_user.email:
+        existing_user = crud_user.user.get_user_by_email(db, email=user_in.email)
+        if existing_user and existing_user.id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="An account with this email already exists.",
+            )
+    # Check for username conflict if username is being updated
+    if user_in.username and user_in.username != current_user.username:
+        existing_user = crud_user.user.get_user_by_username(
+            db, username=user_in.username
+        )
+        if existing_user and existing_user.id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="An account with this username already exists.",
+            )
+
+    updated_user = crud_user.user.update_user(
+        db=db, db_user=current_user, user_in=user_in
+    )
+    return updated_user
+
+
+# Example of an admin-only route (if you implement is_superuser or roles)
+# @router.get("/", response_model=List[user_schema.User], tags=["users"])
+# def read_users(
+#     db: Session = Depends(deps_db.get_db),
+#     skip: int = 0,
+#     limit: int = 100,
+#     current_user: models.User = Depends(deps_auth.get_current_active_superuser), # Requires superuser
+# ) -> Any:
+#     """
+#     Retrieve users. (Admin only)
+#     """
+#     users = crud_user.user.get_users(db, skip=skip, limit=limit)
+#     return users
+
+
+@router.get("/{user_id}", response_model=user_schema.User, tags=["users"])
+def read_user_by_id(
+    user_id: int,
+    db: Session = Depends(deps_db.get_db),
+    current_user: models.User = Depends(
+        deps_auth.get_current_active_user
+    ),  # Or superuser for access control
+) -> Any:
+    """
+    Get a specific user by id.
+    Accessible by admin or the user themselves (if user_id == current_user.id).
+    """
+    user = crud_user.user.get_user(db, user_id=user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+
+    # Add access control: only admin or the user themselves can access.
+    # if user.id != current_user.id and not current_user.is_superuser: # Assuming is_superuser flag
+    #     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions")
+    # For now, allowing any authenticated user to fetch if ID exists. Refine if needed.
+    return user
+
+
+# Add other user-related endpoints here if needed (e.g., delete user - typically admin)

--- a/crud/__init__.py
+++ b/crud/__init__.py
@@ -1,0 +1,16 @@
+from .crud_user import user
+from .crud_trade import trade
+from .crud_strategy import strategy
+from .crud_analytics import (
+    trade_analytics,
+)  # Changed name to avoid conflict with the model
+
+# You can also define specific imports if you prefer not to import the whole object
+# from .crud_user import get_user, create_user, etc.
+
+__all__ = [
+    "user",
+    "trade",
+    "strategy",
+    "trade_analytics",
+]

--- a/crud/crud_analytics.py
+++ b/crud/crud_analytics.py
@@ -1,0 +1,122 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+import datetime
+
+from ai_trader import models
+from schemas import analytics as analytics_schema
+
+
+class CRUDTradeAnalytics:
+    def get_analytic(
+        self, db: Session, analytic_id: int
+    ) -> Optional[models.TradeAnalytics]:
+        return (
+            db.query(models.TradeAnalytics)
+            .filter(
+                models.TradeAnalytics.id == analytic_id,
+                models.TradeAnalytics.is_deleted == False,
+            )
+            .first()
+        )
+
+    def get_analytics_by_user(
+        self, db: Session, user_id: int, skip: int = 0, limit: int = 100
+    ) -> List[models.TradeAnalytics]:
+        return (
+            db.query(models.TradeAnalytics)
+            .filter(
+                models.TradeAnalytics.user_id == user_id,
+                models.TradeAnalytics.is_deleted == False,
+            )
+            .order_by(models.TradeAnalytics.analysis_date.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def get_analytics_by_strategy(
+        self, db: Session, strategy_id: int, skip: int = 0, limit: int = 100
+    ) -> List[models.TradeAnalytics]:
+        return (
+            db.query(models.TradeAnalytics)
+            .filter(
+                models.TradeAnalytics.strategy_id == strategy_id,
+                models.TradeAnalytics.is_deleted == False,
+            )
+            .order_by(models.TradeAnalytics.analysis_date.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def get_all_analytics(
+        self, db: Session, skip: int = 0, limit: int = 100
+    ) -> List[models.TradeAnalytics]:
+        return (
+            db.query(models.TradeAnalytics)
+            .filter(models.TradeAnalytics.is_deleted == False)
+            .order_by(models.TradeAnalytics.analysis_date.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def create_analytic_entry(
+        self,
+        db: Session,
+        *,
+        analytics_in: analytics_schema.AnalyticsDataCreate,
+        user_id: int,
+        strategy_id: Optional[int] = None
+    ) -> models.TradeAnalytics:
+        db_analytic_entry = models.TradeAnalytics(
+            **analytics_in.model_dump(),  # Pydantic V2
+            user_id=user_id,
+            strategy_id=strategy_id,
+            analysis_date=datetime.date.today()  # Set current date for analysis
+        )
+        db.add(db_analytic_entry)
+        db.commit()
+        db.refresh(db_analytic_entry)
+        return db_analytic_entry
+
+    def update_analytic_entry(
+        self,
+        db: Session,
+        *,
+        db_analytic_entry: models.TradeAnalytics,
+        analytics_in: analytics_schema.AnalyticsDataUpdate
+    ) -> models.TradeAnalytics:
+        update_data = analytics_in.model_dump(exclude_unset=True)  # Pydantic V2
+
+        for field, value in update_data.items():
+            setattr(db_analytic_entry, field, value)
+
+        db.add(db_analytic_entry)
+        db.commit()
+        db.refresh(db_analytic_entry)
+        return db_analytic_entry
+
+    def delete_analytic_entry(
+        self, db: Session, *, analytic_id: int
+    ) -> Optional[models.TradeAnalytics]:
+        db_analytic_entry = (
+            db.query(models.TradeAnalytics)
+            .filter(
+                models.TradeAnalytics.id == analytic_id,
+                models.TradeAnalytics.is_deleted == False,
+            )
+            .first()
+        )
+        if db_analytic_entry:
+            # Soft delete:
+            # db_analytic_entry.is_deleted = True
+            # db_analytic_entry.deleted_at = datetime.datetime.utcnow()
+            db_analytic_entry.soft_delete(session=db)  # Pass the session
+            db.commit()
+            db.refresh(db_analytic_entry)
+            return db_analytic_entry
+        return None
+
+
+trade_analytics = CRUDTradeAnalytics()

--- a/crud/crud_strategy.py
+++ b/crud/crud_strategy.py
@@ -1,0 +1,91 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from ai_trader import models
+from schemas import strategy as strategy_schema
+
+
+class CRUDStrategy:
+    def get_strategy(self, db: Session, strategy_id: int) -> Optional[models.Strategy]:
+        return (
+            db.query(models.Strategy)
+            .filter(
+                models.Strategy.id == strategy_id, models.Strategy.is_deleted == False
+            )
+            .first()
+        )
+
+    def get_strategies_by_user(
+        self, db: Session, user_id: int, skip: int = 0, limit: int = 100
+    ) -> List[models.Strategy]:
+        return (
+            db.query(models.Strategy)
+            .filter(
+                models.Strategy.user_id == user_id, models.Strategy.is_deleted == False
+            )
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def get_all_strategies(
+        self, db: Session, skip: int = 0, limit: int = 100
+    ) -> List[models.Strategy]:
+        return (
+            db.query(models.Strategy)
+            .filter(models.Strategy.is_deleted == False)
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def create_strategy(
+        self, db: Session, *, strategy_in: strategy_schema.StrategyCreate, user_id: int
+    ) -> models.Strategy:
+        db_strategy = models.Strategy(
+            **strategy_in.model_dump(), user_id=user_id  # Pydantic V2  # Set the owner
+        )
+        db.add(db_strategy)
+        db.commit()
+        db.refresh(db_strategy)
+        return db_strategy
+
+    def update_strategy(
+        self,
+        db: Session,
+        *,
+        db_strategy: models.Strategy,
+        strategy_in: strategy_schema.StrategyUpdate
+    ) -> models.Strategy:
+        update_data = strategy_in.model_dump(exclude_unset=True)  # Pydantic V2
+
+        for field, value in update_data.items():
+            setattr(db_strategy, field, value)
+
+        db.add(db_strategy)
+        db.commit()
+        db.refresh(db_strategy)
+        return db_strategy
+
+    def delete_strategy(
+        self, db: Session, *, strategy_id: int
+    ) -> Optional[models.Strategy]:
+        db_strategy = (
+            db.query(models.Strategy)
+            .filter(
+                models.Strategy.id == strategy_id, models.Strategy.is_deleted == False
+            )
+            .first()
+        )
+        if db_strategy:
+            # Soft delete:
+            # db_strategy.is_deleted = True
+            # db_strategy.deleted_at = datetime.datetime.utcnow()
+            db_strategy.soft_delete(session=db)  # Pass the session
+            db.commit()
+            db.refresh(db_strategy)
+            return db_strategy
+        return None
+
+
+strategy = CRUDStrategy()

--- a/crud/crud_trade.py
+++ b/crud/crud_trade.py
@@ -1,0 +1,81 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from ai_trader import models
+from schemas import trade as trade_schema
+
+
+class CRUDTrade:
+    def get_trade(self, db: Session, trade_id: int) -> Optional[models.Trade]:
+        return (
+            db.query(models.Trade)
+            .filter(models.Trade.id == trade_id, models.Trade.is_deleted == False)
+            .first()
+        )
+
+    def get_trades_by_user(
+        self, db: Session, user_id: int, skip: int = 0, limit: int = 100
+    ) -> List[models.Trade]:
+        return (
+            db.query(models.Trade)
+            .filter(models.Trade.user_id == user_id, models.Trade.is_deleted == False)
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def get_all_trades(
+        self, db: Session, skip: int = 0, limit: int = 100
+    ) -> List[models.Trade]:
+        return (
+            db.query(models.Trade)
+            .filter(models.Trade.is_deleted == False)
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def create_trade(
+        self, db: Session, *, trade_in: trade_schema.TradeCreate, user_id: int
+    ) -> models.Trade:
+        db_trade = models.Trade(
+            **trade_in.model_dump(),  # Pydantic V2
+            user_id=user_id  # Ensure user_id is set
+        )
+        db.add(db_trade)
+        db.commit()
+        db.refresh(db_trade)
+        return db_trade
+
+    def update_trade(
+        self, db: Session, *, db_trade: models.Trade, trade_in: trade_schema.TradeUpdate
+    ) -> models.Trade:
+        update_data = trade_in.model_dump(exclude_unset=True)  # Pydantic V2
+
+        for field, value in update_data.items():
+            setattr(db_trade, field, value)
+
+        db.add(db_trade)  # or db.merge(db_trade) if db_trade could be detached
+        db.commit()
+        db.refresh(db_trade)
+        return db_trade
+
+    def delete_trade(self, db: Session, *, trade_id: int) -> Optional[models.Trade]:
+        db_trade = (
+            db.query(models.Trade)
+            .filter(models.Trade.id == trade_id, models.Trade.is_deleted == False)
+            .first()
+        )
+        if db_trade:
+            # Soft delete:
+            # db_trade.is_deleted = True
+            # db_trade.deleted_at = datetime.datetime.utcnow()
+            # Use the model's soft_delete method if it handles cascades or related logic
+            db_trade.soft_delete(session=db)  # Pass the session
+            db.commit()
+            db.refresh(db_trade)
+            return db_trade
+        return None
+
+
+trade = CRUDTrade()

--- a/crud/crud_user.py
+++ b/crud/crud_user.py
@@ -1,0 +1,116 @@
+from sqlalchemy.orm import Session
+from passlib.context import CryptContext  # For password hashing
+from typing import Optional  # Added Optional
+
+# import datetime  # F401: Unused
+
+from ai_trader import models  # Assuming models.py is in ai_trader directory
+from schemas import user as user_schema  # Alias to avoid naming conflict
+
+# Password hashing setup
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+class CRUDUser:
+    def get_user(self, db: Session, user_id: int) -> Optional[models.User]:
+        return (
+            db.query(models.User)
+            .filter(models.User.id == user_id, models.User.is_deleted == False)
+            .first()
+        )
+
+    def get_user_by_email(self, db: Session, email: str) -> Optional[models.User]:
+        return (
+            db.query(models.User)
+            .filter(models.User.email == email, models.User.is_deleted == False)
+            .first()
+        )
+
+    def get_user_by_username(self, db: Session, username: str) -> Optional[models.User]:
+        return (
+            db.query(models.User)
+            .filter(models.User.username == username, models.User.is_deleted == False)
+            .first()
+        )
+
+    def get_users(
+        self, db: Session, skip: int = 0, limit: int = 100
+    ) -> list[models.User]:
+        return (
+            db.query(models.User)
+            .filter(models.User.is_deleted == False)
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def create_user(
+        self, db: Session, *, user_in: user_schema.UserCreate
+    ) -> models.User:
+        hashed_password = get_password_hash(user_in.password)
+        db_user = models.User(
+            username=user_in.username,
+            email=user_in.email,
+            hashed_password=hashed_password,
+        )
+        db.add(db_user)
+        db.commit()
+        db.refresh(db_user)
+        return db_user
+
+    def update_user(
+        self, db: Session, *, db_user: models.User, user_in: user_schema.UserUpdate
+    ) -> models.User:
+        update_data = user_in.model_dump(exclude_unset=True)  # Pydantic V2
+
+        if "password" in update_data and update_data["password"]:
+            hashed_password = get_password_hash(update_data["password"])
+            db_user.hashed_password = hashed_password
+            del update_data["password"]  # Don't try to set it directly below
+
+        for field, value in update_data.items():
+            setattr(db_user, field, value)
+
+        db.add(db_user)
+        db.commit()
+        db.refresh(db_user)
+        return db_user
+
+    def delete_user(self, db: Session, *, user_id: int) -> Optional[models.User]:
+        db_user = (
+            db.query(models.User)
+            .filter(models.User.id == user_id, models.User.is_deleted == False)
+            .first()
+        )
+        if db_user:
+            # Soft delete:
+            # db_user.is_deleted = True
+            # db_user.deleted_at = datetime.datetime.utcnow()
+            # For soft delete with cascade, use the method from the model
+            db_user.soft_delete(session=db)  # Pass the session
+            db.commit()
+            db.refresh(db_user)
+            return db_user
+        return None  # Or raise HTTPException(status_code=404, detail="User not found")
+
+    # Authenticate user (typically used in auth logic, but can be here for user-specific checks)
+    def authenticate(
+        self, db: Session, *, username: str, password: str
+    ) -> Optional[models.User]:
+        user = self.get_user_by_username(db, username=username)
+        if not user:
+            return None
+        if not verify_password(password, user.hashed_password):
+            return None
+        return user
+
+
+user = CRUDUser()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,9 @@ pandas-ta
 yfinance
 python-binance
 setuptools
+faker
+fastapi
+uvicorn[standard]
+python-jose[cryptography]
+passlib[bcrypt]
+pydantic[email]

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,31 @@
+from .user import User, UserCreate, UserUpdate, UserInDB
+from .token import Token, TokenData
+from .trade import Trade, TradeCreate, TradeUpdate, TradeInDB
+from .strategy import Strategy, StrategyCreate, StrategyUpdate, StrategyInDB
+from .analytics import (
+    AnalyticsData,
+    AnalyticsDataCreate,
+    AnalyticsDataUpdate,
+    AnalyticsDataInDB,
+)
+
+__all__ = [
+    "User",
+    "UserCreate",
+    "UserUpdate",
+    "UserInDB",
+    "Token",
+    "TokenData",
+    "Trade",
+    "TradeCreate",
+    "TradeUpdate",
+    "TradeInDB",
+    "Strategy",
+    "StrategyCreate",
+    "StrategyUpdate",
+    "StrategyInDB",
+    "AnalyticsData",
+    "AnalyticsDataCreate",
+    "AnalyticsDataUpdate",
+    "AnalyticsDataInDB",
+]

--- a/schemas/analytics.py
+++ b/schemas/analytics.py
@@ -1,0 +1,53 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Text
+import datetime
+
+
+class AnalyticsDataBase(BaseModel):
+    total_trades: int = Field(..., ge=0)
+    win_rate: float = Field(..., ge=0.0, le=1.0)  # Percentage, e.g., 0.75 for 75%
+    total_pnl: float  # Profit and Loss
+    avg_risk_reward: Optional[float] = None
+    max_drawdown: Optional[float] = None  # Percentage or absolute value
+    notes: Optional[Text] = None
+    # user_id and strategy_id will often be path parameters or derived from context
+    # analysis_date will be set by the system on creation
+
+
+class AnalyticsDataCreate(AnalyticsDataBase):
+    # If user_id or strategy_id need to be part of the payload:
+    # user_id: int
+    # strategy_id: Optional[int] = None
+    pass
+
+
+class AnalyticsDataUpdate(BaseModel):
+    total_trades: Optional[int] = Field(None, ge=0)
+    win_rate: Optional[float] = Field(None, ge=0.0, le=1.0)
+    total_pnl: Optional[float] = None
+    avg_risk_reward: Optional[float] = None
+    max_drawdown: Optional[float] = None
+    notes: Optional[Text] = None
+
+
+class AnalyticsDataInDBBase(AnalyticsDataBase):
+    id: int
+    user_id: int
+    strategy_id: Optional[int] = None
+    analysis_date: datetime.date
+    is_deleted: bool = False  # Assuming soft delete
+
+    class Config:
+        orm_mode = True  # Pydantic V1 or from_attributes = True for V2
+
+
+class AnalyticsData(AnalyticsDataInDBBase):
+    """Properties to return to client."""
+
+    pass
+
+
+class AnalyticsDataInDB(AnalyticsDataInDBBase):
+    """Properties stored in DB."""
+
+    pass

--- a/schemas/strategy.py
+++ b/schemas/strategy.py
@@ -1,0 +1,48 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any
+import datetime
+
+
+class StrategyBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = None
+    model_version: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+    # api_key: Optional[str] = None # Sensitive, handle carefully. Not usually part of create/update directly.
+    # user_id will be set by the system (e.g. from current authenticated user)
+
+
+class StrategyCreate(StrategyBase):
+    pass
+
+
+class StrategyUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = None
+    model_version: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+    # api_key: Optional[str] = None # Consider a separate endpoint for managing API keys
+
+
+class StrategyInDBBase(StrategyBase):
+    id: int
+    user_id: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    is_deleted: bool = False  # Assuming soft delete
+
+    class Config:
+        orm_mode = True  # Pydantic V1 or from_attributes = True for V2
+
+
+class Strategy(StrategyInDBBase):
+    """Properties to return to client."""
+
+    pass
+
+
+class StrategyInDB(StrategyInDBBase):
+    """Properties stored in DB."""
+
+    # api_key: Optional[str] = None # If stored directly; consider encryption or separate secure storage
+    pass

--- a/schemas/token.py
+++ b/schemas/token.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class TokenData(BaseModel):
+    username: Optional[str] = None
+    # You might want to add other fields like user_id, scopes, etc.
+    # For example:
+    # user_id: Optional[int] = None
+    # scopes: list[str] = []

--- a/schemas/trade.py
+++ b/schemas/trade.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel
+from typing import Optional
+import datetime
+from decimal import Decimal  # For precise numeric types
+
+# Assuming TradeType and OrderSide enums are defined elsewhere,
+# or you can redefine them here or import if they are in a shared location.
+# For now, using string placeholders.
+# from ai_trader.models import TradeType as ModelTradeType (if accessible)
+
+
+class TradeBase(BaseModel):
+    symbol: str
+    quantity: Decimal
+    price: Decimal
+    trade_type: str  # Should ideally be an Enum: Literal["BUY", "SELL"]
+    commission: Optional[Decimal] = None
+    commission_asset: Optional[str] = None
+    # user_id will be set by the system, not by client on creation usually
+    # order_id might be optional if a trade can exist without a direct order link in some contexts
+
+
+class TradeCreate(TradeBase):
+    # user_id: int # If client needs to specify it (e.g. admin creating trade for user)
+    order_id: Optional[int] = None
+
+
+class TradeUpdate(BaseModel):
+    quantity: Optional[Decimal] = None
+    price: Optional[Decimal] = None
+    commission: Optional[Decimal] = None
+    commission_asset: Optional[str] = None
+    # Other fields that are updatable
+
+
+class TradeInDBBase(TradeBase):
+    id: int
+    user_id: int
+    order_id: Optional[int] = None
+    timestamp: datetime.datetime
+    is_deleted: bool = False  # Assuming soft delete
+
+    class Config:
+        orm_mode = True  # Pydantic V1 or from_attributes = True for V2
+
+
+class Trade(TradeInDBBase):
+    """Properties to return to client."""
+
+    pass
+
+
+class TradeInDB(TradeInDBBase):
+    """Properties stored in DB."""
+
+    pass

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -1,0 +1,45 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+import datetime
+
+# --- Base Schemas ---
+
+
+class UserBase(BaseModel):
+    username: str
+    email: EmailStr
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class UserUpdate(BaseModel):
+    username: Optional[str] = None
+    email: Optional[EmailStr] = None
+    password: Optional[str] = None  # For password updates
+
+
+# --- Properties to receive via API on creation, but not stored in DB as is (e.g. password) ---
+# (UserCreate already handles this for password)
+
+
+# --- Properties shared by models stored in DB ---
+class UserInDBBase(UserBase):
+    id: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    is_deleted: bool = False  # Assuming soft delete is used
+
+    class Config:
+        orm_mode = True  # Pydantic V1 way, or from_attributes = True for Pydantic V2
+
+
+# --- Properties to return to client (filters out sensitive data like hashed_password) ---
+class User(UserInDBBase):
+    pass
+
+
+# --- Properties stored in DB (includes hashed_password if needed for internal use) ---
+class UserInDB(UserInDBBase):
+    hashed_password: str

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,0 +1,1 @@
+# This file makes 'tests/api' a Python package.

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,257 @@
+import pytest
+from typing import Generator, Any
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.pool import StaticPool  # Recommended for SQLite in tests
+
+from ai_trader.models import Base  # Corrected import for Base
+from api.main import app  # Your FastAPI application
+from api.deps.db import get_db  # The dependency we want to override
+from ai_trader.config import settings  # To potentially use a test DB URL if defined
+from ai_trader import (
+    models as GLOBAL_MODELS,
+)  # Make alias available globally in this file
+
+# --- Test Database Setup ---
+# Using an in-memory SQLite database for tests
+# SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+# More robust: Use a test-specific database URL from settings or a default
+TEST_DATABASE_URL = (
+    settings.DATABASE_URL + "_test" if settings.DATABASE_URL else "sqlite:///:memory:"
+)
+if "sqlite" in TEST_DATABASE_URL:
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},  # Needed for SQLite
+        poolclass=StaticPool,  # Use StaticPool for SQLite in-memory for tests
+    )
+else:
+    engine = create_engine(TEST_DATABASE_URL)
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Create tables in the test database
+# This should happen once before any tests run that interact with the DB.
+# A fixture can manage this, or it can be done globally here if careful.
+# For simplicity here, but pytest-django or similar might offer more robust setup/teardown.
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_test_tables():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+# --- Override `get_db` Dependency for Tests ---
+def override_get_db() -> Generator[Session, Any, None]:
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+# --- Fixtures ---
+@pytest.fixture(
+    scope="module"
+)  # Or "session" if client can be reused across all test files
+def client() -> Generator[TestClient, Any, None]:
+    """
+    Yield a TestClient instance that uses the overridden get_db.
+    """
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="session")  # Session scope for initial DB setup for all tests
+def module_db_session(create_test_tables: None) -> Generator[Session, Any, None]:
+    # create_test_tables ensures tables are ready for the whole test session
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="function")
+def db_session(
+    create_test_tables: None,
+) -> Generator[Session, Any, None]:  # Depends on table creation
+    """
+    Yield a database session for direct interaction during tests (function scope).
+    Ensures the session is closed after the test.
+    """
+    # This fixture provides a session directly from TestingSessionLocal
+    # which is what override_get_db also uses.
+    # Useful for setting up data or verifying DB state outside of API calls.
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# Fixture to get a regular user's token and the user model instance
+@pytest.fixture(scope="module")
+def normal_user_token_headers(
+    client: TestClient, module_db_session: Session
+) -> dict[str, str]:
+    from crud import crud_user  # Imports crud_user.user object
+    from crud.crud_user import (
+        get_password_hash,
+    )  # Import directly from crud_user module
+    from schemas.user import UserCreate
+    from ai_trader.config import settings
+    from api.deps.auth import create_access_token
+
+    # GLOBAL_MODELS is now defined at the top of the file
+
+    # Ensure a consistent test user for token generation
+    # This user is created once per module if not existing.
+    username = settings.PROJECT_NAME.lower().replace(" ", "") + "_testuser@example.com"
+    email = username
+    password = "testpassword"
+
+    user = crud_user.user.get_user_by_username(module_db_session, username=username)
+    if not user:
+        hashed_password = get_password_hash(password)  # Use the same hashing as in app
+        user = GLOBAL_MODELS.User(
+            username=username, email=email, hashed_password=hashed_password
+        )
+        module_db_session.add(user)
+        module_db_session.commit()
+        module_db_session.refresh(user)
+
+    access_token = create_access_token(data={"sub": user.username})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture(scope="module")
+def test_user(module_db_session: Session) -> GLOBAL_MODELS.User:
+    from crud import crud_user  # crud_user.user object
+    from ai_trader.config import settings
+
+    # This fixture provides the user object corresponding to normal_user_token_headers
+    username = settings.PROJECT_NAME.lower().replace(" ", "") + "_testuser@example.com"
+    user = crud_user.user.get_user_by_username(module_db_session, username=username)
+    assert (
+        user is not None
+    ), "Test user should have been created by normal_user_token_headers fixture"
+    return user
+
+
+# --- Fixture for a second user (useful for testing permissions) ---
+@pytest.fixture(scope="module")
+def other_user(module_db_session: Session) -> GLOBAL_MODELS.User:
+    from crud import crud_user  # Imports crud_user.user object
+    from crud.crud_user import (
+        get_password_hash,
+    )  # Import directly from crud_user module
+    from schemas.user import UserCreate
+
+    # GLOBAL_MODELS is now defined at the top of the file
+
+    username = "otheruser@example.com"
+    email = "otheruser@example.com"
+    password = "otherpassword"
+
+    user = crud_user.user.get_user_by_username(module_db_session, username=username)
+    if not user:
+        hashed_password = get_password_hash(password)
+        user = GLOBAL_MODELS.User(
+            username=username, email=email, hashed_password=hashed_password
+        )
+        module_db_session.add(user)
+        module_db_session.commit()
+        module_db_session.refresh(user)
+    return user
+
+
+# --- Data Seeding Fixtures (using Faker and concepts from seed scripts) ---
+from faker import Faker
+import random
+from decimal import Decimal
+from datetime import datetime, timedelta, timezone
+
+fake = Faker()
+
+
+@pytest.fixture(scope="module")
+def test_assets(module_db_session: Session) -> list[GLOBAL_MODELS.Asset]:
+    # GLOBAL_MODELS is now defined at the top of the file
+    assets_data = [
+        {"symbol": "BTCUSD", "name": "Bitcoin USD", "asset_type": "CRYPTO"},
+        {"symbol": "ETHUSD", "name": "Ethereum USD", "asset_type": "CRYPTO"},
+        {"symbol": "AAPL", "name": "Apple Inc.", "asset_type": "STOCK"},
+    ]
+    created_assets = []
+    for asset_data in assets_data:
+        asset = (
+            module_db_session.query(GLOBAL_MODELS.Asset)
+            .filter_by(symbol=asset_data["symbol"])
+            .first()
+        )
+        if not asset:
+            asset = GLOBAL_MODELS.Asset(**asset_data)
+            module_db_session.add(asset)
+            module_db_session.commit()  # Commit each to ensure they are available if needed by other fixtures
+            module_db_session.refresh(asset)
+        created_assets.append(asset)
+    return created_assets
+
+
+@pytest.fixture(scope="function")  # Function scope if strategies are modified by tests
+def test_strategy_for_user(
+    db_session: Session, test_user: GLOBAL_MODELS.User
+) -> GLOBAL_MODELS.Strategy:
+    # GLOBAL_MODELS is now defined at the top of the file
+    strategy_data = {
+        "name": f"Test Strategy {fake.word()}",
+        "description": fake.sentence(),
+        "user_id": test_user.id,
+        "parameters": {"param1": random.randint(1, 100), "param2": fake.word()},
+    }
+    strategy = GLOBAL_MODELS.Strategy(**strategy_data)
+    db_session.add(strategy)
+    db_session.commit()
+    db_session.refresh(strategy)
+    return strategy
+
+
+@pytest.fixture(scope="function")
+def test_trade_for_user(
+    db_session: Session,
+    test_user: GLOBAL_MODELS.User,
+    test_assets: list[GLOBAL_MODELS.Asset],
+) -> GLOBAL_MODELS.Trade:
+    # GLOBAL_MODELS is now defined at the top of the file
+    from ai_trader.models import TradeType  # Enum can be imported directly
+
+    selected_asset = random.choice(test_assets)
+
+    # Create a simple order first (as trades are often linked to orders)
+    # For API tests, we might not need full order details if trade creation is direct
+    # However, if CRUD layer for trade requires order_id, we need one.
+    # Assuming Trade model has user_id directly and order_id is optional or handled by CRUD
+
+    trade_data = {
+        "user_id": test_user.id,
+        "symbol": selected_asset.symbol,
+        "quantity": Decimal(str(random.uniform(0.1, 10.0))),
+        "price": Decimal(str(random.uniform(100.0, 50000.0))),
+        "timestamp": datetime.now(timezone.utc) - timedelta(days=random.randint(0, 30)),
+        "trade_type": random.choice(list(TradeType)),
+        "commission": Decimal(str(random.uniform(0.1, 5.0))),
+        "commission_asset": "USD",
+    }
+    trade = GLOBAL_MODELS.Trade(**trade_data)
+    db_session.add(trade)
+    db_session.commit()
+    db_session.refresh(trade)
+    return trade

--- a/tests/api/test_analytics.py
+++ b/tests/api/test_analytics.py
@@ -1,0 +1,297 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from typing import Dict, List, Optional  # For type hints
+import datetime
+
+from ai_trader import models
+from schemas import analytics as analytics_schema
+from crud import crud_analytics, crud_strategy  # For creating related strategies
+
+
+# --- Helper to generate analytics data ---
+def get_analytics_create_data(
+    total_trades: int = 100, win_rate: float = 0.75, total_pnl: float = 5000.0
+) -> dict:
+    return {
+        "total_trades": total_trades,
+        "win_rate": win_rate,
+        "total_pnl": total_pnl,
+        "avg_risk_reward": 1.5,
+        "max_drawdown": 0.10,  # 10%
+        "notes": "Initial performance data.",
+    }
+
+
+# --- Analytics Endpoint Tests ---
+
+
+def test_create_analytics_entry_for_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_user: models.User,
+) -> None:
+    data = get_analytics_create_data()
+
+    response = client.post(
+        "/api/v1/analytics/", headers=normal_user_token_headers, json=data
+    )
+
+    assert response.status_code == 201, response.text
+    created_entry_data = response.json()
+    assert created_entry_data["total_trades"] == data["total_trades"]
+    assert created_entry_data["user_id"] == test_user.id
+    assert (
+        created_entry_data["strategy_id"] is None
+    )  # No strategy_id passed as query param
+    assert "id" in created_entry_data
+    assert (
+        datetime.date.fromisoformat(created_entry_data["analysis_date"])
+        == datetime.date.today()
+    )
+
+
+def test_create_analytics_entry_for_user_with_strategy(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_user: models.User,
+    test_strategy_for_user: models.Strategy,  # Fixture that creates a strategy for test_user
+) -> None:
+    data = get_analytics_create_data(total_trades=50)
+    strategy_id = test_strategy_for_user.id
+
+    response = client.post(
+        f"/api/v1/analytics/?strategy_id={strategy_id}",
+        headers=normal_user_token_headers,
+        json=data,
+    )
+
+    assert response.status_code == 201, response.text
+    created_entry_data = response.json()
+    assert created_entry_data["total_trades"] == data["total_trades"]
+    assert created_entry_data["user_id"] == test_user.id
+    assert created_entry_data["strategy_id"] == strategy_id
+
+
+def test_create_analytics_entry_with_nonexistent_strategy(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_user: models.User,
+) -> None:
+    data = get_analytics_create_data()
+    non_existent_strategy_id = 99999
+    response = client.post(
+        f"/api/v1/analytics/?strategy_id={non_existent_strategy_id}",
+        headers=normal_user_token_headers,
+        json=data,
+    )
+    assert response.status_code == 404  # Not Found for strategy
+    assert "Strategy with id" in response.json()["detail"]
+
+
+def test_create_analytics_entry_with_strategy_of_other_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],  # Belongs to test_user
+    test_user: models.User,
+    other_user: models.User,  # Another user
+    db_session: Session,
+) -> None:
+    from schemas import strategy as strategy_schema  # Added import
+
+    # Create a strategy for other_user
+    other_user_strategy = crud_strategy.strategy.create_strategy(
+        db=db_session,
+        strategy_in=strategy_schema.StrategyCreate(name="OtherUserStrat", description="desc"),  # type: ignore
+        user_id=other_user.id,
+    )
+    data = get_analytics_create_data()
+
+    response = client.post(
+        f"/api/v1/analytics/?strategy_id={other_user_strategy.id}",
+        headers=normal_user_token_headers,
+        json=data,
+    )
+    assert response.status_code == 403  # Forbidden
+    assert "Strategy does not belong to the current user" in response.json()["detail"]
+
+
+def test_read_analytics_entry_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    test_user: models.User,
+) -> None:
+    entry = crud_analytics.trade_analytics.create_analytic_entry(
+        db=db_session,
+        analytics_in=analytics_schema.AnalyticsDataCreate(
+            **get_analytics_create_data()
+        ),
+        user_id=test_user.id,
+    )
+
+    response = client.get(
+        f"/api/v1/analytics/{entry.id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 200, response.text
+    entry_data = response.json()
+    assert entry_data["id"] == entry.id
+    assert entry_data["user_id"] == test_user.id
+
+
+def test_read_analytics_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    test_user: models.User,
+) -> None:
+    crud_analytics.trade_analytics.create_analytic_entry(
+        db=db_session,
+        analytics_in=analytics_schema.AnalyticsDataCreate(
+            **get_analytics_create_data(total_trades=10)
+        ),
+        user_id=test_user.id,
+    )
+    crud_analytics.trade_analytics.create_analytic_entry(
+        db=db_session,
+        analytics_in=analytics_schema.AnalyticsDataCreate(
+            **get_analytics_create_data(total_trades=20)
+        ),
+        user_id=test_user.id,
+    )
+
+    response = client.get("/api/v1/analytics/user/", headers=normal_user_token_headers)
+    assert response.status_code == 200, response.text
+    entries_list = response.json()
+    assert isinstance(entries_list, list)
+    assert len(entries_list) >= 2
+    for entry_data in entries_list:
+        assert entry_data["user_id"] == test_user.id
+
+
+def test_read_analytics_by_strategy_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    test_user: models.User,
+    test_strategy_for_user: models.Strategy,  # Strategy owned by test_user
+) -> None:
+    strategy_id = test_strategy_for_user.id
+    crud_analytics.trade_analytics.create_analytic_entry(
+        db=db_session,
+        analytics_in=analytics_schema.AnalyticsDataCreate(
+            **get_analytics_create_data(total_trades=30)
+        ),
+        user_id=test_user.id,
+        strategy_id=strategy_id,
+    )
+    crud_analytics.trade_analytics.create_analytic_entry(
+        db=db_session,
+        analytics_in=analytics_schema.AnalyticsDataCreate(
+            **get_analytics_create_data(total_trades=40)
+        ),
+        user_id=test_user.id,
+        strategy_id=strategy_id,
+    )
+
+    response = client.get(
+        f"/api/v1/analytics/strategy/{strategy_id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 200, response.text
+    entries_list = response.json()
+    assert isinstance(entries_list, list)
+    assert len(entries_list) >= 2
+    for entry_data in entries_list:
+        assert entry_data["user_id"] == test_user.id
+        assert entry_data["strategy_id"] == strategy_id
+
+
+def test_read_analytics_by_strategy_of_other_user_forbidden(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],  # Belongs to test_user
+    db_session: Session,
+    other_user: models.User,  # Another user
+):
+    from schemas import strategy as strategy_schema  # Added import
+
+    # Strategy belonging to other_user
+    other_user_strategy = crud_strategy.strategy.create_strategy(
+        db=db_session,
+        strategy_in=strategy_schema.StrategyCreate(name="OtherUserStratAnalytics", description="desc"),  # type: ignore
+        user_id=other_user.id,
+    )
+    response = client.get(
+        f"/api/v1/analytics/strategy/{other_user_strategy.id}",
+        headers=normal_user_token_headers,
+    )
+    assert response.status_code == 403  # Forbidden
+    assert "Strategy does not belong to the current user" in response.json()["detail"]
+
+
+def test_update_analytics_entry_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    test_user: models.User,
+) -> None:
+    entry = crud_analytics.trade_analytics.create_analytic_entry(
+        db=db_session,
+        analytics_in=analytics_schema.AnalyticsDataCreate(
+            **get_analytics_create_data()
+        ),
+        user_id=test_user.id,
+    )
+    update_data = {"total_pnl": 12345.67, "notes": "Updated notes."}
+
+    response = client.put(
+        f"/api/v1/analytics/{entry.id}",
+        headers=normal_user_token_headers,
+        json=update_data,
+    )
+    assert response.status_code == 200, response.text
+    updated_entry_data = response.json()
+    assert updated_entry_data["total_pnl"] == 12345.67
+    assert updated_entry_data["notes"] == "Updated notes."
+
+
+def test_delete_analytics_entry_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    test_user: models.User,
+) -> None:
+    entry = crud_analytics.trade_analytics.create_analytic_entry(
+        db=db_session,
+        analytics_in=analytics_schema.AnalyticsDataCreate(
+            **get_analytics_create_data()
+        ),
+        user_id=test_user.id,
+    )
+    entry_id_to_delete = entry.id
+
+    response = client.delete(
+        f"/api/v1/analytics/{entry_id_to_delete}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 200, response.text
+    deleted_entry_data = response.json()
+    assert deleted_entry_data["id"] == entry_id_to_delete
+    assert deleted_entry_data["is_deleted"] is True
+
+    # Verify in DB
+    db_entry = crud_analytics.trade_analytics.get_analytic(
+        db=db_session, analytic_id=entry_id_to_delete
+    )
+    assert db_entry is None
+
+
+# Add tests for:
+# - Permissions when trying to update/delete analytics of another user.
+# - Invalid input for create/update (e.g., win_rate > 1.0).
+# - Pagination for list endpoints.
+# - Behavior when associated strategy is deleted (if analytics entries should also be soft-deleted - depends on cascade logic).
+#   The current soft_delete in Strategy model cascades to TradeAnalytics. So, if a strategy is soft-deleted,
+#   its related analytics entries should also be soft-deleted. This interaction needs testing.
+#   Example:
+#   1. Create User U1, Strategy S1 (for U1), Analytics A1 (for S1, U1).
+#   2. Soft delete S1 (e.g., via API or direct CRUD call for test setup).
+#   3. Try to GET A1 via API. Expect 404 (as it should also be soft-deleted).
+#   4. Query DB directly to confirm A1.is_deleted is True.

--- a/tests/api/test_strategies.py
+++ b/tests/api/test_strategies.py
@@ -1,0 +1,237 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from typing import Dict, List  # For type hints
+
+from ai_trader import models  # For type hinting models.User, models.Strategy
+from schemas import strategy as strategy_schema  # For creating StrategyCreate schemas
+from crud import crud_strategy  # To potentially verify DB state directly
+
+
+# --- Helper to generate strategy data ---
+def get_strategy_create_data(
+    name: str = "My Algo Strategy", description: str = "A test strategy"
+) -> dict:
+    return {
+        "name": name,
+        "description": description,
+        "model_version": "1.0.0",
+        "parameters": {"lookback": 20, "threshold": 0.5},
+    }
+
+
+# --- Strategy Endpoint Tests ---
+
+
+def test_create_strategy_for_current_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_user: models.User,
+) -> None:
+    data = get_strategy_create_data(name="User1 New Strategy")
+
+    response = client.post(
+        "/api/v1/strategies/", headers=normal_user_token_headers, json=data
+    )
+
+    assert response.status_code == 201, response.text
+    created_strategy_data = response.json()
+    assert created_strategy_data["name"] == data["name"]
+    assert created_strategy_data["user_id"] == test_user.id
+    assert "id" in created_strategy_data
+    assert created_strategy_data["parameters"]["lookback"] == 20
+
+
+def test_create_strategy_no_auth(client: TestClient) -> None:
+    data = get_strategy_create_data()
+    response = client.post("/api/v1/strategies/", json=data)
+    assert response.status_code == 401  # Unauthorized
+
+
+def test_read_strategy_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_strategy_for_user: models.Strategy,
+) -> None:
+    # test_strategy_for_user fixture creates a strategy for the 'test_user'
+    response = client.get(
+        f"/api/v1/strategies/{test_strategy_for_user.id}",
+        headers=normal_user_token_headers,
+    )
+    assert response.status_code == 200, response.text
+    strategy_data = response.json()
+    assert strategy_data["id"] == test_strategy_for_user.id
+    assert strategy_data["user_id"] == test_strategy_for_user.user_id
+    assert strategy_data["name"] == test_strategy_for_user.name
+
+
+def test_read_strategy_not_found(
+    client: TestClient, normal_user_token_headers: Dict[str, str]
+) -> None:
+    non_existent_id = 888888
+    response = client.get(
+        f"/api/v1/strategies/{non_existent_id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 404
+    assert "Strategy not found" in response.json()["detail"]
+
+
+def test_read_strategy_forbidden_other_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],  # Token for test_user
+    db_session: Session,
+    other_user: models.User,  # A different user
+):
+    # Create a strategy for other_user
+    other_user_strategy_data = get_strategy_create_data(name="Other User Strategy")
+    strategy_in_schema = strategy_schema.StrategyCreate(**other_user_strategy_data)
+    other_strategy = crud_strategy.strategy.create_strategy(
+        db=db_session, strategy_in=strategy_in_schema, user_id=other_user.id
+    )
+
+    # test_user tries to access other_user's strategy
+    response = client.get(
+        f"/api/v1/strategies/{other_strategy.id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 403  # Forbidden
+    assert "Not enough permissions" in response.json()["detail"]
+
+
+def test_read_strategies_for_current_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    test_user: models.User,
+) -> None:
+    # Ensure user has at least a couple of strategies
+    crud_strategy.strategy.create_strategy(
+        db=db_session,
+        strategy_in=strategy_schema.StrategyCreate(
+            **get_strategy_create_data("Strat A")
+        ),
+        user_id=test_user.id,
+    )
+    crud_strategy.strategy.create_strategy(
+        db=db_session,
+        strategy_in=strategy_schema.StrategyCreate(
+            **get_strategy_create_data("Strat B")
+        ),
+        user_id=test_user.id,
+    )
+
+    response = client.get("/api/v1/strategies/", headers=normal_user_token_headers)
+    assert response.status_code == 200, response.text
+    strategies_list = response.json()
+    assert isinstance(strategies_list, list)
+    assert len(strategies_list) >= 2  # Based on strategies created
+    for strat_data in strategies_list:
+        assert strat_data["user_id"] == test_user.id
+
+
+def test_update_strategy_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_strategy_for_user: models.Strategy,
+) -> None:
+    update_data = {
+        "name": "Updated Strategy Name",
+        "parameters": {"lookback": 30, "new_param": "test"},
+    }
+
+    response = client.put(
+        f"/api/v1/strategies/{test_strategy_for_user.id}",
+        headers=normal_user_token_headers,
+        json=update_data,
+    )
+    assert response.status_code == 200, response.text
+    updated_strategy_data = response.json()
+    assert updated_strategy_data["name"] == "Updated Strategy Name"
+    assert updated_strategy_data["parameters"]["lookback"] == 30
+    assert updated_strategy_data["parameters"]["new_param"] == "test"
+    assert (
+        updated_strategy_data["description"] == test_strategy_for_user.description
+    )  # Check non-updated field
+
+
+def test_update_strategy_forbidden_other_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    other_user: models.User,
+):
+    other_strategy = crud_strategy.strategy.create_strategy(
+        db=db_session,
+        strategy_in=strategy_schema.StrategyCreate(
+            **get_strategy_create_data("Other Strat")
+        ),
+        user_id=other_user.id,
+    )
+    update_data = {"name": "Attempted Update"}
+
+    response = client.put(
+        f"/api/v1/strategies/{other_strategy.id}",
+        headers=normal_user_token_headers,
+        json=update_data,
+    )
+    assert response.status_code == 403
+    assert "Not enough permissions" in response.json()["detail"]
+
+
+def test_delete_strategy_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_strategy_for_user: models.Strategy,
+    db_session: Session,
+) -> None:
+    strategy_id_to_delete = test_strategy_for_user.id
+    response = client.delete(
+        f"/api/v1/strategies/{strategy_id_to_delete}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 200, response.text
+    deleted_strategy_data = response.json()
+    assert deleted_strategy_data["id"] == strategy_id_to_delete
+    assert deleted_strategy_data["is_deleted"] == True
+
+    # Verify in DB
+    db_strategy = crud_strategy.strategy.get_strategy(
+        db=db_session, strategy_id=strategy_id_to_delete
+    )
+    assert db_strategy is None
+
+
+def test_delete_strategy_forbidden_other_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    other_user: models.User,
+):
+    other_strategy = crud_strategy.strategy.create_strategy(
+        db=db_session,
+        strategy_in=strategy_schema.StrategyCreate(
+            **get_strategy_create_data("Other Strat to Delete")
+        ),
+        user_id=other_user.id,
+    )
+
+    response = client.delete(
+        f"/api/v1/strategies/{other_strategy.id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 403
+    assert "Not enough permissions" in response.json()["detail"]
+
+
+# Add tests for:
+# - Invalid input data for create/update (e.g., missing name, invalid parameter structure if validated)
+# - Uniqueness constraint on (user_id, name) if enforced by DB/model.
+# - Pagination for list endpoint.
+# - Cascading deletes (e.g., if deleting a strategy also deletes related signals or analytics - depends on model relationships and soft_delete logic).
+#   The current soft_delete on Strategy model cascades to Orders, Signals, BacktestResults, TradeAnalytics. This needs careful testing.
+#   For API tests, we'd check that related items are also soft-deleted or handled as per business logic.
+#   This might involve creating these related items first, then deleting the strategy and verifying.
+#   Example:
+#   1. Create User U1.
+#   2. Create Strategy S1 for U1.
+#   3. Create Analytics A1 for S1 and U1.
+#   4. Delete S1 via API.
+#   5. Verify S1 is soft-deleted.
+#   6. Verify A1 is also soft-deleted (by trying to GET it and expecting 404, or querying DB directly).

--- a/tests/api/test_trades.py
+++ b/tests/api/test_trades.py
@@ -1,0 +1,240 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from typing import Dict, List  # For type hints
+from decimal import Decimal
+
+from ai_trader import models  # For type hinting models.User, models.Trade
+from schemas import trade as trade_schema  # For creating TradeCreate schemas
+from crud import crud_trade  # To potentially verify DB state directly
+
+
+# --- Helper to generate trade data ---
+def get_trade_create_data(
+    symbol: str = "BTCUSD", quantity: float = 1.0, price: float = 50000.0
+) -> dict:
+    return {
+        "symbol": symbol,
+        "quantity": quantity,  # Pydantic will convert to Decimal if schema expects it
+        "price": price,  # Pydantic will convert
+        "trade_type": "BUY",  # Example
+        "commission": 5.0,
+        "commission_asset": "USD",
+    }
+
+
+# --- Trade Endpoint Tests ---
+
+
+def test_create_trade_for_current_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_user: models.User,
+    test_assets: List[models.Asset],
+) -> None:
+    selected_asset = test_assets[0]
+    data = get_trade_create_data(symbol=selected_asset.symbol)
+
+    response = client.post(
+        "/api/v1/trades/", headers=normal_user_token_headers, json=data
+    )
+
+    assert response.status_code == 201, response.text
+    created_trade_data = response.json()
+    assert created_trade_data["symbol"] == selected_asset.symbol
+    assert created_trade_data["user_id"] == test_user.id
+    assert Decimal(str(created_trade_data["quantity"])) == Decimal(
+        str(data["quantity"])
+    )  # Compare as Decimal
+    assert "id" in created_trade_data
+
+
+def test_create_trade_no_auth(
+    client: TestClient, test_assets: List[models.Asset]
+) -> None:
+    data = get_trade_create_data(symbol=test_assets[0].symbol)
+    response = client.post("/api/v1/trades/", json=data)
+    assert response.status_code == 401  # Unauthorized
+
+
+def test_read_trade_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_trade_for_user: models.Trade,
+) -> None:
+    # test_trade_for_user fixture creates a trade for the 'test_user'
+    response = client.get(
+        f"/api/v1/trades/{test_trade_for_user.id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 200, response.text
+    trade_data = response.json()
+    assert trade_data["id"] == test_trade_for_user.id
+    assert trade_data["user_id"] == test_trade_for_user.user_id
+    assert trade_data["symbol"] == test_trade_for_user.symbol
+
+
+def test_read_trade_not_found(
+    client: TestClient, normal_user_token_headers: Dict[str, str]
+) -> None:
+    non_existent_id = 999999
+    response = client.get(
+        f"/api/v1/trades/{non_existent_id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 404
+    assert "Trade not found" in response.json()["detail"]
+
+
+def test_read_trade_forbidden_other_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],  # Token for test_user
+    db_session: Session,
+    other_user: models.User,  # A different user
+    test_assets: List[models.Asset],
+):
+    # Create a trade for other_user
+    other_user_trade_data = get_trade_create_data(symbol=test_assets[0].symbol)
+    # Manually create trade for other_user using CRUD or a fixture if available
+    trade_in_schema = trade_schema.TradeCreate(**other_user_trade_data)
+    other_trade = crud_trade.trade.create_trade(
+        db=db_session, trade_in=trade_in_schema, user_id=other_user.id
+    )
+
+    # test_user tries to access other_user's trade
+    response = client.get(
+        f"/api/v1/trades/{other_trade.id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 403  # Forbidden
+    assert "Not enough permissions" in response.json()["detail"]
+
+
+def test_read_trades_for_current_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    test_user: models.User,
+    test_assets: List[models.Asset],
+) -> None:
+    # Ensure user has at least one trade (test_trade_for_user could be used if its scope allows multiples, or create one here)
+    crud_trade.trade.create_trade(
+        db=db_session,
+        trade_in=trade_schema.TradeCreate(
+            **get_trade_create_data(test_assets[0].symbol)
+        ),
+        user_id=test_user.id,
+    )
+    crud_trade.trade.create_trade(
+        db=db_session,
+        trade_in=trade_schema.TradeCreate(
+            **get_trade_create_data(test_assets[1].symbol)
+        ),
+        user_id=test_user.id,
+    )
+
+    response = client.get("/api/v1/trades/", headers=normal_user_token_headers)
+    assert response.status_code == 200, response.text
+    trades_list = response.json()
+    assert isinstance(trades_list, list)
+    assert len(trades_list) >= 2  # Based on trades created above
+    for trade_data in trades_list:
+        assert trade_data["user_id"] == test_user.id
+
+
+def test_update_trade_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_trade_for_user: models.Trade,
+) -> None:
+    update_data = {"quantity": 123.45, "commission": 7.89}  # Example update fields
+
+    response = client.put(
+        f"/api/v1/trades/{test_trade_for_user.id}",
+        headers=normal_user_token_headers,
+        json=update_data,
+    )
+    assert response.status_code == 200, response.text
+    updated_trade_data = response.json()
+    assert Decimal(str(updated_trade_data["quantity"])) == Decimal("123.45")
+    assert Decimal(str(updated_trade_data["commission"])) == Decimal("7.89")
+    assert (
+        updated_trade_data["symbol"] == test_trade_for_user.symbol
+    )  # Ensure other fields are intact or as expected
+
+
+def test_update_trade_forbidden_other_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],  # Token for test_user
+    db_session: Session,
+    other_user: models.User,
+    test_assets: List[models.Asset],
+):
+    other_trade = crud_trade.trade.create_trade(
+        db=db_session,
+        trade_in=trade_schema.TradeCreate(
+            **get_trade_create_data(test_assets[0].symbol)
+        ),
+        user_id=other_user.id,
+    )
+    update_data = {"quantity": 10.0}
+
+    response = client.put(
+        f"/api/v1/trades/{other_trade.id}",
+        headers=normal_user_token_headers,
+        json=update_data,
+    )
+    assert response.status_code == 403
+    assert "Not enough permissions" in response.json()["detail"]
+
+
+def test_delete_trade_owned_by_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_trade_for_user: models.Trade,
+    db_session: Session,
+) -> None:
+    trade_id_to_delete = test_trade_for_user.id
+    response = client.delete(
+        f"/api/v1/trades/{trade_id_to_delete}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 200, response.text
+    deleted_trade_data = response.json()
+    assert deleted_trade_data["id"] == trade_id_to_delete
+    assert (
+        deleted_trade_data["is_deleted"] == True
+    )  # Assuming schema includes this for soft delete response
+
+    # Verify in DB (it should be marked as deleted)
+    db_trade = crud_trade.trade.get_trade(db=db_session, trade_id=trade_id_to_delete)
+    assert db_trade is None  # Because get_trade filters out deleted ones
+
+    # Optionally, query with deleted to confirm:
+    # trade_with_deleted = db_session.query(models.Trade).filter(models.Trade.id == trade_id_to_delete).first()
+    # assert trade_with_deleted is not None
+    # assert trade_with_deleted.is_deleted == True
+
+
+def test_delete_trade_forbidden_other_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    other_user: models.User,
+    test_assets: List[models.Asset],
+):
+    other_trade = crud_trade.trade.create_trade(
+        db=db_session,
+        trade_in=trade_schema.TradeCreate(
+            **get_trade_create_data(test_assets[0].symbol)
+        ),
+        user_id=other_user.id,
+    )
+
+    response = client.delete(
+        f"/api/v1/trades/{other_trade.id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 403
+    assert "Not enough permissions" in response.json()["detail"]
+
+
+# Add tests for:
+# - Invalid input data for create/update (e.g., negative quantity, invalid symbol format if validated)
+# - Pagination for list endpoint (if skip/limit are fully tested)
+# - Filtering trades by other criteria if implemented (e.g., by symbol, date range)

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -1,0 +1,247 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from typing import Dict
+
+from ai_trader import models  # For type hinting models.User
+from schemas.user import UserCreate
+from crud import crud_user
+from ai_trader.config import settings  # For any default settings or test user details
+
+# A utility to get random string for unique usernames/emails in tests
+import random
+import string
+
+
+def random_lower_string(length: int = 8) -> str:
+    return "".join(random.choices(string.ascii_lowercase, k=length))
+
+
+def random_email() -> str:
+    return f"{random_lower_string()}@{random_lower_string()}.com"
+
+
+# --- User Registration and Login Tests ---
+
+
+def test_create_user_new_email_username(
+    client: TestClient, db_session: Session
+) -> None:
+    username = random_lower_string()
+    email = random_email()
+    password = random_lower_string(12)
+    data = {"username": username, "email": email, "password": password}
+
+    response = client.post("/api/v1/users/register", json=data)
+
+    assert response.status_code == 201, response.text
+    created_user = response.json()
+    assert created_user["email"] == email
+    assert created_user["username"] == username
+    assert "id" in created_user
+    assert "hashed_password" not in created_user  # Ensure password is not returned
+
+    user_in_db = crud_user.user.get_user_by_username(db_session, username=username)
+    assert user_in_db
+    assert user_in_db.email == email
+    # You might want to verify the password, but that requires hashing the test password
+    # and comparing, or using the authenticate method. For now, presence is enough.
+
+
+def test_create_user_duplicate_username(
+    client: TestClient, test_user: models.User
+) -> None:
+    # test_user fixture already creates a user
+    data = {
+        "username": test_user.username,  # Using existing username
+        "email": random_email(),  # New email
+        "password": "newpassword123",
+    }
+    response = client.post("/api/v1/users/register", json=data)
+    assert response.status_code == 400
+    assert "username already exists" in response.json()["detail"].lower()
+
+
+def test_create_user_duplicate_email(
+    client: TestClient, test_user: models.User
+) -> None:
+    data = {
+        "username": random_lower_string(),  # New username
+        "email": test_user.email,  # Using existing email
+        "password": "newpassword123",
+    }
+    response = client.post("/api/v1/users/register", json=data)
+    assert response.status_code == 400
+    assert "email already exists" in response.json()["detail"].lower()
+
+
+def test_login_successful(client: TestClient, test_user: models.User) -> None:
+    # test_user fixture ensures user "testuser@example.com" with password "testpassword" exists
+    login_data = {
+        "username": test_user.username,  # from conftest test_user
+        "password": "testpassword",  # from conftest test_user
+    }
+    response = client.post("/api/v1/users/login", data=login_data)
+    assert response.status_code == 200, response.text
+    tokens = response.json()
+    assert "access_token" in tokens
+    assert tokens["token_type"] == "bearer"
+
+
+def test_login_incorrect_password(client: TestClient, test_user: models.User) -> None:
+    login_data = {"username": test_user.username, "password": "wrongpassword"}
+    response = client.post("/api/v1/users/login", data=login_data)
+    assert response.status_code == 401
+    assert "Incorrect username or password" in response.json()["detail"]
+
+
+def test_login_nonexistent_user(client: TestClient) -> None:
+    login_data = {"username": "nonexistentuser@example.com", "password": "anypassword"}
+    response = client.post("/api/v1/users/login", data=login_data)
+    assert response.status_code == 401  # Or 404, depending on how auth is implemented
+    # 401 is common to avoid user enumeration
+    assert "Incorrect username or password" in response.json()["detail"]
+
+
+# --- Authenticated User Endpoint Tests (/me) ---
+
+
+def test_read_users_me_successful(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_user: models.User,
+) -> None:
+    response = client.get("/api/v1/users/me", headers=normal_user_token_headers)
+    assert response.status_code == 200, response.text
+    current_user_data = response.json()
+    assert current_user_data["email"] == test_user.email
+    assert current_user_data["username"] == test_user.username
+    assert current_user_data["id"] == test_user.id
+
+
+def test_read_users_me_no_token(client: TestClient) -> None:
+    response = client.get("/api/v1/users/me")
+    assert response.status_code == 401  # Expecting unauthorized
+    assert (
+        "Not authenticated" in response.json()["detail"]
+    )  # Or "Could not validate credentials"
+
+
+def test_update_user_me_successful(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_user: models.User,
+    db_session: Session,
+) -> None:
+    new_username = random_lower_string(10)
+    new_email = random_email()
+    update_data = {"username": new_username, "email": new_email}
+
+    response = client.put(
+        "/api/v1/users/me", headers=normal_user_token_headers, json=update_data
+    )
+    assert response.status_code == 200, response.text
+    updated_user_data = response.json()
+    assert updated_user_data["username"] == new_username
+    assert updated_user_data["email"] == new_email
+
+    # Verify in DB
+    db_session.refresh(test_user)  # Refresh the original test_user instance
+    assert test_user.username == new_username
+    assert test_user.email == new_email
+
+
+def test_update_user_me_duplicate_email_other_user(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: Session,
+    test_user: models.User,
+):
+    # Create another user first
+    other_username = random_lower_string()
+    other_email = random_email()
+    other_password = "password123"
+    other_user_in = UserCreate(
+        username=other_username, email=other_email, password=other_password
+    )
+    crud_user.user.create_user(db_session, user_in=other_user_in)
+
+    # Attempt to update current user (test_user) to other_user's email
+    update_data = {"email": other_email}
+    response = client.put(
+        "/api/v1/users/me", headers=normal_user_token_headers, json=update_data
+    )
+    assert response.status_code == 400
+    assert "email already exists" in response.json()["detail"].lower()
+
+
+# --- Get User by ID Test --- (Example, assuming /users/{user_id} exists)
+
+
+def test_read_user_by_id_successful(
+    client: TestClient,
+    normal_user_token_headers: Dict[str, str],
+    test_user: models.User,
+) -> None:
+    response = client.get(
+        f"/api/v1/users/{test_user.id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 200, response.text
+    user_data = response.json()
+    assert user_data["id"] == test_user.id
+    assert user_data["username"] == test_user.username
+
+
+def test_read_user_by_id_not_found(
+    client: TestClient, normal_user_token_headers: Dict[str, str]
+) -> None:
+    non_existent_id = 9999999
+    response = client.get(
+        f"/api/v1/users/{non_existent_id}", headers=normal_user_token_headers
+    )
+    assert response.status_code == 404
+    assert "User not found" in response.json()["detail"]
+
+
+# Add more tests:
+# - Updating password for /me
+# - Attempting to update /me with username that conflicts with another user
+# - Testing authentication with invalid/expired tokens (more involved, may need to mock datetime)
+# - If admin routes for listing/managing users are added, test those with appropriate admin user fixture.
+# - Test soft deletion of user and ensure they cannot log in / access authenticated routes.
+
+
+@pytest.mark.skip(
+    reason="Soft delete test needs user recreation or careful state management"
+)
+def test_login_soft_deleted_user(
+    client: TestClient, db_session: Session, test_user: models.User
+):
+    # Soft delete the user
+    crud_user.user.delete_user(db=db_session, user_id=test_user.id)
+    db_session.commit()  # Ensure delete is committed
+
+    login_data = {
+        "username": test_user.username,
+        "password": "testpassword",  # Original password
+    }
+    response = client.post("/api/v1/users/login", data=login_data)
+
+    # Expected behavior:
+    # 1. crud_user.authenticate might return None if it filters by is_deleted=False.
+    # 2. Or, login route explicitly checks user.is_deleted.
+    # The user router's login endpoint checks user.is_deleted.
+    assert (
+        response.status_code == 400
+    )  # Based on current implementation in users.py router
+    assert "Inactive user" in response.json()["detail"]
+
+    # Cleanup: Reactivate or recreate user if other tests depend on this user being active
+    # For simplicity, this test is skipped or should be run last/isolated.
+    # Or, create a new user specifically for this test.
+    # test_user_reloaded = crud_user.user.get_user(db_session, user_id=test_user.id) # This will fail if get_user filters deleted
+    # if test_user_reloaded:
+    #     test_user_reloaded.is_deleted = False
+    #     test_user_reloaded.deleted_at = None
+    #     db_session.add(test_user_reloaded)
+    #     db_session.commit()


### PR DESCRIPTION
This commit introduces the foundational structure for the FastAPI API layer, including routers, CRUD operations, Pydantic schemas, and authentication mechanisms for users, trades, strategies, and analytics.

Key changes:
- Created directory structure: api/, api/routers/, api/deps/, schemas/, crud/, tests/api/
- Implemented api/main.py as the FastAPI entrypoint.
- Added api/deps/db.py for DB session management (get_db).
- Added api/deps/auth.py for JWT-based authentication.
- Defined Pydantic models in schemas/ for request/response validation.
- Implemented CRUD logic in crud/ to separate DB operations.
- Created routers in api/routers/ for users, trades, strategies, analytics with basic CRUD endpoints, auth, and tagging.
- Developed initial unit tests using pytest and TestClient in tests/api/, including fixtures for data seeding.
- Updated requirements.txt with necessary dependencies (fastapi, uvicorn, python-jose, passlib, pydantic[email], faker).
- Ran 'black' for auto-formatting on new/modified Python files.
- Started addressing flake8 linting issues in the new API-related code.

Further work would involve completing all flake8 fixes, comprehensive testing, and potentially more advanced error handling or feature refinements.